### PR TITLE
Add SemanticKernelChatCompletionAgent to adapt ChatCompletionAgent as a RoutedAgent

### DIFF
--- a/python/packages/autogen-core/autogen/core/agents/semantic_kernel_chat_completion_agent.py
+++ b/python/packages/autogen-core/autogen/core/agents/semantic_kernel_chat_completion_agent.py
@@ -1,0 +1,56 @@
+import logging
+from collections.abc import AsyncGenerator, AsyncIterable
+from typing import Any, ClassVar
+
+from semantic_kernel.agents import Agent
+from semantic_kernel.agents.channels.agent_channel import AgentChannel
+from semantic_kernel.agents.channels.chat_history_channel import ChatHistoryChannel
+from semantic_kernel.connectors.ai.chat_completion_client_base import ChatCompletionClientBase
+from semantic_kernel.connectors.ai.prompt_execution_settings import PromptExecutionSettings
+from semantic_kernel.const import DEFAULT_SERVICE_NAME
+from semantic_kernel.contents.chat_history import ChatHistory
+from semantic_kernel.contents.chat_message_content import ChatMessageContent
+from semantic_kernel.contents.streaming_chat_message_content import StreamingChatMessageContent
+from semantic_kernel.contents.utils.author_role import AuthorRole
+from semantic_kernel.exceptions import KernelServiceNotFoundError
+from semantic_kernel.functions.kernel_arguments import KernelArguments
+from semantic_kernel.functions.kernel_function import TEMPLATE_FORMAT_MAP
+from semantic_kernel.prompt_template.prompt_template_config import PromptTemplateConfig
+
+class SemanticKernelChatCompletionAgent(Agent):
+    def __init__(self, name: str, service_id: str = DEFAULT_SERVICE_NAME):
+        super().__init__(name)
+        self.service_id = service_id
+
+    async def generate_reply_async(self, messages: list[ChatMessageContent], kernel: "Kernel", arguments: KernelArguments) -> ChatMessageContent:
+        chat_history = self.build_chat_history(messages)
+        chat_completion_service, settings = await self._get_chat_completion_service_and_settings(kernel, arguments)
+        async for message in chat_completion_service.complete_chat_async(chat_history, settings):
+            return message
+
+    def build_chat_history(self, messages: list[ChatMessageContent]) -> ChatHistory:
+        history = ChatHistory()
+        for message in messages:
+            history.add_message(message)
+        return history
+
+    def process_message(self, message: Any) -> ChatMessageContent:
+        if isinstance(message, str):
+            return ChatMessageContent(role=AuthorRole.USER, content=message)
+        elif isinstance(message, dict):
+            return ChatMessageContent(role=AuthorRole.USER, content=message.get("content", ""))
+        else:
+            raise ValueError("Unsupported message type")
+
+    async def _get_chat_completion_service_and_settings(
+        self, kernel: "Kernel", arguments: KernelArguments
+    ) -> tuple[ChatCompletionClientBase, PromptExecutionSettings]:
+        chat_completion_service, settings = kernel.select_ai_service(arguments=arguments, type=ChatCompletionClientBase)
+
+        if not chat_completion_service:
+            raise KernelServiceNotFoundError(f"Chat completion service not found with service_id: {self.service_id}")
+
+        assert isinstance(chat_completion_service, ChatCompletionClientBase)  # nosec
+        assert settings is not None  # nosec
+
+        return chat_completion_service, settings

--- a/python/packages/autogen-core/tests/test_semantic_kernel_chat_completion_agent.py
+++ b/python/packages/autogen-core/tests/test_semantic_kernel_chat_completion_agent.py
@@ -1,0 +1,39 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from autogen.core.agents.semantic_kernel_chat_completion_agent import SemanticKernelChatCompletionAgent
+from semantic_kernel.contents.chat_message_content import ChatMessageContent
+from semantic_kernel.contents.utils.author_role import AuthorRole
+from semantic_kernel.contents.chat_history import ChatHistory
+from semantic_kernel.functions.kernel_arguments import KernelArguments
+
+class TestSemanticKernelChatCompletionAgent:
+
+    @pytest.mark.asyncio
+    async def test_generate_reply_async(self):
+        agent = SemanticKernelChatCompletionAgent(name="test_agent")
+        agent.build_chat_history = MagicMock(return_value=ChatHistory())
+        agent._get_chat_completion_service_and_settings = AsyncMock(return_value=(AsyncMock(), MagicMock()))
+        agent._get_chat_completion_service_and_settings.return_value[0].complete_chat_async = AsyncMock(return_value=AsyncMock(__aiter__=lambda s: iter([ChatMessageContent(role=AuthorRole.USER, content="test_reply")])))
+
+        result = await agent.generate_reply_async(messages=[], kernel=MagicMock(), arguments=KernelArguments())
+        assert result.content == "test_reply"
+
+    def test_build_chat_history(self):
+        agent = SemanticKernelChatCompletionAgent(name="test_agent")
+        messages = [ChatMessageContent(role=AuthorRole.USER, content="test_message")]
+        history = agent.build_chat_history(messages)
+        assert len(history.messages) == 1
+        assert history.messages[0].content == "test_message"
+
+    def test_process_message(self):
+        agent = SemanticKernelChatCompletionAgent(name="test_agent")
+        message = "test_message"
+        result = agent.process_message(message)
+        assert result.content == "test_message"
+
+        message = {"content": "test_message"}
+        result = agent.process_message(message)
+        assert result.content == "test_message"
+
+        with pytest.raises(ValueError):
+            agent.process_message(123)


### PR DESCRIPTION


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jsburckhardt/autogen/pull/1?shareId=13a17455-c465-415f-aa55-8190f8854ced).